### PR TITLE
Remove deprecated Specification#has_rdoc= call side

### DIFF
--- a/compass-excess.gemspec
+++ b/compass-excess.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Ben Darlow"]
   spec.email         = ["ben@kapowaz.net"]
   spec.license       = 'MIT'
-  spec.has_rdoc      = false
   spec.files         = `git ls-files`.split("\n")
   spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   spec.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
Fixes the following deprecation:

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /opt/ruby/vendor/bundler/bundler/gems/compass-excess-8557dd5a33e3/compass-excess.gemspec:15.
```

