### PR TITLE
Change background-image-file mixin to make 3x density images optional

### DIFF
--- a/stylesheets/_images.scss
+++ b/stylesheets/_images.scss
@@ -6,7 +6,7 @@
   height: $height;
 }
 
-@mixin background-image-file($url, $background-size: null, $background-position: null, $background-repeat: no-repeat, $type: 'png', $retina: true) {
+@mixin background-image-file($url, $background-size: null, $background-position: null, $background-repeat: no-repeat, $type: 'png', $retina: true, $include_3x: true) {
   @if $url == none {
     background-image: none;
 
@@ -30,9 +30,10 @@
         @media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2) {
           & { background-image: image-url($url + '@2x.' + $type); }
         }
-
-        @media only screen and (-webkit-min-device-pixel-ratio: 3), only screen and (min-device-pixel-ratio: 3) {
-          & { background-image: image-url($url + '@3x.' + $type); }
+        @if ($include_3x) {
+          @media only screen and (-webkit-min-device-pixel-ratio: 3), only screen and (min-device-pixel-ratio: 3) {
+            & { background-image: image-url($url + '@3x.' + $type); }
+          }
         }
       }
     }


### PR DESCRIPTION
Hello @kapowaz! We recently found ourselves needing to restrict this mixin to outputting rulesets with `background-image` properties with 1x and 2x pixel-density image values because we didn't have appropriate 3x images available. We duplicated the mixin in our SCSS and patched it: that patch is proposed as an upstream patch here.

I notice that the `background-image-gradient` mixin similarly outputs rulesets with 3x background images, but I wasn't sure how to change the signature of the method, as it uses an arglist, and I doubted I could elegantly make the change. If you think it's worthwhile to alter this mixin as well, could you give me a pointer on how to proceed?